### PR TITLE
Add admin dashboard metrics tiles and expandable client rows

### DIFF
--- a/backend/src/modules/admin/admin.controller.js
+++ b/backend/src/modules/admin/admin.controller.js
@@ -26,6 +26,25 @@ const getClients = async (req, res, next) => {
   }
 };
 
+/**
+ * Get aggregate metrics across all tenants
+ * GET /api/admin/metrics
+ */
+const getMetrics = async (req, res, next) => {
+  try {
+    const metrics = await adminService.getAggregateMetrics();
+
+    res.status(200).json({
+      success: true,
+      data: metrics,
+    });
+  } catch (error) {
+    logger.error(`Error in getMetrics controller: ${error.message}`);
+    next(error);
+  }
+};
+
 module.exports = {
   getClients,
+  getMetrics,
 };

--- a/backend/src/modules/admin/admin.routes.js
+++ b/backend/src/modules/admin/admin.routes.js
@@ -33,4 +33,7 @@ const adminLimiter = rateLimit({
 // GET /api/admin/clients - Get all clients (tenants)
 router.get('/clients', adminLimiter, adminAuthMiddleware, adminController.getClients);
 
+// GET /api/admin/metrics - Get aggregate metrics across all tenants
+router.get('/metrics', adminLimiter, adminAuthMiddleware, adminController.getMetrics);
+
 module.exports = router;

--- a/backend/src/modules/admin/admin.service.js
+++ b/backend/src/modules/admin/admin.service.js
@@ -2,41 +2,244 @@
  * Admin Service
  * Business logic for admin operations
  */
+const { Op, fn, col, literal } = require('sequelize');
 const { Tenant } = require('../tenants/tenant.model');
+const { CallLog } = require('../telephony/callLog.model');
+const { Appointment, APPOINTMENT_STATUS } = require('../appointments/appointment.model');
+const { Employee } = require('../employees/employee.model');
+const { Service } = require('../services/service.model');
 const { AppError } = require('../../middleware/errorHandler');
 const logger = require('../../utils/logger');
 
 /**
- * Get all clients (tenants) with their details
- * @returns {Promise<Array>} - List of all clients
+ * Get metrics for a specific tenant
+ * @param {string} tenantId - Tenant ID
+ * @returns {Promise<Object>} - Tenant metrics
+ */
+const getMetricsForTenant = async (tenantId) => {
+  try {
+    // Get call metrics
+    const callStats = await CallLog.findOne({
+      where: { tenantId },
+      attributes: [
+        [fn('COUNT', col('id')), 'totalCalls'],
+        [fn('SUM', col('duration')), 'totalMinutes'],
+        [fn('AVG', col('duration')), 'avgDuration'],
+      ],
+      raw: true,
+    });
+
+    // Get appointment metrics
+    const appointmentStats = await Appointment.findAll({
+      where: { tenantId },
+      attributes: [
+        'status',
+        [fn('COUNT', col('id')), 'count'],
+      ],
+      group: ['status'],
+      raw: true,
+    });
+
+    const appointmentsByStatus = {};
+    let totalAppointments = 0;
+    appointmentStats.forEach(stat => {
+      appointmentsByStatus[stat.status] = parseInt(stat.count, 10);
+      totalAppointments += parseInt(stat.count, 10);
+    });
+
+    // Get upcoming appointments count
+    const upcomingAppointments = await Appointment.count({
+      where: {
+        tenantId,
+        startTime: { [Op.gt]: new Date() },
+        status: { [Op.in]: [APPOINTMENT_STATUS.SCHEDULED, APPOINTMENT_STATUS.CONFIRMED] },
+      },
+    });
+
+    // Get employee count
+    const employeeCount = await Employee.count({ where: { tenantId } });
+
+    // Get service count
+    const serviceCount = await Service.count({ where: { tenantId } });
+
+    // Get tenant details for phone number and trial info
+    const tenant = await Tenant.findByPk(tenantId, {
+      attributes: ['twilioPhoneNumber', 'trialEndsAt', 'planType', 'stripeCustomerId'],
+    });
+
+    // Calculate trial days remaining
+    let trialDaysRemaining = null;
+    if (tenant?.trialEndsAt) {
+      const now = new Date();
+      const trialEnd = new Date(tenant.trialEndsAt);
+      trialDaysRemaining = Math.max(0, Math.ceil((trialEnd - now) / (1000 * 60 * 60 * 24)));
+    }
+
+    return {
+      calls: {
+        total: parseInt(callStats?.totalCalls || 0, 10),
+        totalMinutes: Math.round(parseFloat(callStats?.totalMinutes || 0) / 60), // Convert seconds to minutes
+        avgDuration: Math.round(parseFloat(callStats?.avgDuration || 0)), // In seconds
+      },
+      appointments: {
+        total: totalAppointments,
+        upcoming: upcomingAppointments,
+        completed: appointmentsByStatus[APPOINTMENT_STATUS.COMPLETED] || 0,
+        cancelled: appointmentsByStatus[APPOINTMENT_STATUS.CANCELLED] || 0,
+        scheduled: appointmentsByStatus[APPOINTMENT_STATUS.SCHEDULED] || 0,
+      },
+      employees: employeeCount,
+      services: serviceCount,
+      phoneNumber: tenant?.twilioPhoneNumber || null,
+      trialDaysRemaining,
+      planType: tenant?.planType,
+      stripeCustomerId: tenant?.stripeCustomerId || null,
+    };
+  } catch (error) {
+    logger.error(`Error fetching metrics for tenant ${tenantId}: ${error.message}`);
+    return null;
+  }
+};
+
+/**
+ * Get all clients (tenants) with their details and metrics
+ * @returns {Promise<Array>} - List of all clients with metrics
  */
 const getAllClients = async () => {
   try {
     // Fetch all tenants ordered by creation date (newest first)
     const tenants = await Tenant.findAll({
-      attributes: ['id', 'name', 'slug', 'status', 'planType', 'contactEmail', 'createdAt', 'updatedAt'],
+      attributes: ['id', 'name', 'slug', 'status', 'planType', 'contactEmail', 'twilioPhoneNumber', 'trialEndsAt', 'createdAt', 'updatedAt'],
       order: [['createdAt', 'DESC']],
     });
 
     logger.info(`Retrieved ${tenants.length} clients for admin view`);
 
-    // Format the response
-    return tenants.map(tenant => ({
-      id: tenant.id,
-      name: tenant.name,
-      slug: tenant.slug,
-      status: tenant.status,
-      planType: tenant.planType,
-      contactEmail: tenant.contactEmail,
-      signUpDate: tenant.createdAt,
-      lastUpdated: tenant.updatedAt,
-    }));
+    // Get metrics for each tenant
+    const clientsWithMetrics = await Promise.all(
+      tenants.map(async (tenant) => {
+        const metrics = await getMetricsForTenant(tenant.id);
+
+        return {
+          id: tenant.id,
+          name: tenant.name,
+          slug: tenant.slug,
+          status: tenant.status,
+          planType: tenant.planType,
+          contactEmail: tenant.contactEmail,
+          phoneNumber: tenant.twilioPhoneNumber,
+          signUpDate: tenant.createdAt,
+          lastUpdated: tenant.updatedAt,
+          trialEndsAt: tenant.trialEndsAt,
+          metrics,
+        };
+      })
+    );
+
+    return clientsWithMetrics;
   } catch (error) {
     logger.error(`Error fetching clients for admin: ${error.message}`);
     throw new AppError('Failed to fetch clients', 500, 'FETCH_CLIENTS_FAILED');
   }
 };
 
+/**
+ * Get aggregate metrics across all tenants
+ * @returns {Promise<Object>} - Aggregate metrics
+ */
+const getAggregateMetrics = async () => {
+  try {
+    // Get total call metrics across all tenants
+    const callStats = await CallLog.findOne({
+      attributes: [
+        [fn('COUNT', col('id')), 'totalCalls'],
+        [fn('SUM', col('duration')), 'totalSeconds'],
+        [fn('AVG', col('duration')), 'avgDuration'],
+      ],
+      raw: true,
+    });
+
+    // Get total appointment metrics across all tenants
+    const appointmentStats = await Appointment.findOne({
+      attributes: [
+        [fn('COUNT', col('id')), 'totalAppointments'],
+      ],
+      raw: true,
+    });
+
+    // Get total employees across all tenants
+    const employeeStats = await Employee.findOne({
+      attributes: [
+        [fn('COUNT', col('id')), 'totalEmployees'],
+      ],
+      raw: true,
+    });
+
+    // Get total services across all tenants
+    const serviceStats = await Service.findOne({
+      attributes: [
+        [fn('COUNT', col('id')), 'totalServices'],
+      ],
+      raw: true,
+    });
+
+    // Get trial statistics
+    const now = new Date();
+    const activeTrials = await Tenant.findAll({
+      where: {
+        status: 'active',
+        planType: 'free',
+        trialEndsAt: { [Op.gt]: now },
+      },
+      attributes: ['trialEndsAt'],
+      raw: true,
+    });
+
+    let avgTrialDaysRemaining = 0;
+    if (activeTrials.length > 0) {
+      const totalDays = activeTrials.reduce((sum, tenant) => {
+        const daysRemaining = Math.ceil((new Date(tenant.trialEndsAt) - now) / (1000 * 60 * 60 * 24));
+        return sum + Math.max(0, daysRemaining);
+      }, 0);
+      avgTrialDaysRemaining = Math.round(totalDays / activeTrials.length);
+    }
+
+    // Get paid clients count
+    const paidClients = await Tenant.count({
+      where: {
+        planType: { [Op.ne]: 'free' },
+      },
+    });
+
+    return {
+      calls: {
+        total: parseInt(callStats?.totalCalls || 0, 10),
+        totalMinutes: Math.round(parseFloat(callStats?.totalSeconds || 0) / 60),
+        avgDuration: Math.round(parseFloat(callStats?.avgDuration || 0)),
+      },
+      appointments: {
+        total: parseInt(appointmentStats?.totalAppointments || 0, 10),
+      },
+      employees: {
+        total: parseInt(employeeStats?.totalEmployees || 0, 10),
+      },
+      services: {
+        total: parseInt(serviceStats?.totalServices || 0, 10),
+      },
+      trials: {
+        active: activeTrials.length,
+        avgDaysRemaining: avgTrialDaysRemaining,
+      },
+      paidClients,
+    };
+  } catch (error) {
+    logger.error(`Error fetching aggregate metrics: ${error.message}`);
+    throw new AppError('Failed to fetch aggregate metrics', 500, 'FETCH_METRICS_FAILED');
+  }
+};
+
 module.exports = {
   getAllClients,
+  getAggregateMetrics,
+  getMetricsForTenant,
 };

--- a/frontend/src/pages/AdminClientsPage.vue
+++ b/frontend/src/pages/AdminClientsPage.vue
@@ -13,8 +13,18 @@ const router = useRouter()
 
 // State
 const loading = ref(false)
+const metricsLoading = ref(false)
 const error = ref('')
 const clients = ref<any[]>([])
+const expandedRows = ref<any[]>([])
+const metrics = ref<any>({
+  calls: { total: 0, totalMinutes: 0 },
+  appointments: { total: 0 },
+  employees: { total: 0 },
+  services: { total: 0 },
+  trials: { active: 0, avgDaysRemaining: 0 },
+  paidClients: 0
+})
 
 // Computed
 const totalClients = computed(() => clients.value.length)
@@ -27,15 +37,15 @@ const ADMIN_AUTH_KEY = 'admin_authenticated'
 onMounted(async () => {
   const isAuth = sessionStorage.getItem(ADMIN_AUTH_KEY)
   const storedPassword = sessionStorage.getItem(ADMIN_PASSWORD_KEY)
-  
+
   if (isAuth !== 'true' || !storedPassword) {
     // Not authenticated, redirect to login
     router.push('/criton-admin')
     return
   }
-  
-  // Load clients data
-  await loadClients()
+
+  // Load clients data and metrics in parallel
+  await Promise.all([loadClients(), loadMetrics()])
 })
 
 // Load clients data
@@ -74,9 +84,33 @@ function logout() {
   router.push('/criton-admin')
 }
 
+// Load aggregate metrics
+async function loadMetrics() {
+  metricsLoading.value = true
+
+  const storedPassword = sessionStorage.getItem(ADMIN_PASSWORD_KEY)
+
+  try {
+    const response = await axios.get(
+      `${import.meta.env.VITE_API_URL || ''}/api/admin/metrics`,
+      {
+        headers: {
+          'X-Admin-Password': storedPassword || ''
+        }
+      }
+    )
+
+    metrics.value = response.data.data
+  } catch (err: any) {
+    console.error('Failed to load metrics:', err.response?.data?.error || err.message)
+  } finally {
+    metricsLoading.value = false
+  }
+}
+
 // Refresh data
 async function refreshData() {
-  await loadClients()
+  await Promise.all([loadClients(), loadMetrics()])
 }
 
 // Format date
@@ -178,10 +212,17 @@ function goBack() {
 
       <!-- Client Dashboard -->
       <div class="space-y-6">
-        <!-- Stats Card -->
+        <!-- Summary Metrics Tiles -->
         <Card>
+          <template #title>
+            <div class="flex items-center gap-2">
+              <i class="pi pi-chart-bar text-gray-600"></i>
+              <span>Platform Summary</span>
+            </div>
+          </template>
           <template #content>
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
+            <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
+              <!-- Client Stats -->
               <div class="text-center p-4 bg-blue-50 rounded-lg">
                 <div class="text-3xl font-bold text-blue-600">{{ totalClients }}</div>
                 <div class="text-sm text-gray-600 mt-1">Total Clients</div>
@@ -192,17 +233,41 @@ function goBack() {
                 </div>
                 <div class="text-sm text-gray-600 mt-1">Active Clients</div>
               </div>
-              <div class="text-center p-4 bg-orange-50 rounded-lg">
-                <div class="text-3xl font-bold text-orange-600">
-                  {{ clients.filter(c => c.status === 'pending').length }}
-                </div>
-                <div class="text-sm text-gray-600 mt-1">Pending Clients</div>
-              </div>
               <div class="text-center p-4 bg-purple-50 rounded-lg">
-                <div class="text-3xl font-bold text-purple-600">
-                  {{ clients.filter(c => c.planType !== 'free').length }}
-                </div>
+                <div class="text-3xl font-bold text-purple-600">{{ metrics.paidClients }}</div>
                 <div class="text-sm text-gray-600 mt-1">Paid Plans</div>
+              </div>
+
+              <!-- Trial Stats -->
+              <div class="text-center p-4 bg-orange-50 rounded-lg">
+                <div class="text-3xl font-bold text-orange-600">{{ metrics.trials?.active || 0 }}</div>
+                <div class="text-sm text-gray-600 mt-1">Active Trials</div>
+              </div>
+
+              <!-- Call Stats -->
+              <div class="text-center p-4 bg-indigo-50 rounded-lg">
+                <div class="text-3xl font-bold text-indigo-600">{{ metrics.calls?.total || 0 }}</div>
+                <div class="text-sm text-gray-600 mt-1">Total Calls</div>
+              </div>
+              <div class="text-center p-4 bg-cyan-50 rounded-lg">
+                <div class="text-3xl font-bold text-cyan-600">{{ metrics.calls?.totalMinutes || 0 }}</div>
+                <div class="text-sm text-gray-600 mt-1">Call Minutes</div>
+              </div>
+
+              <!-- Appointment Stats -->
+              <div class="text-center p-4 bg-teal-50 rounded-lg">
+                <div class="text-3xl font-bold text-teal-600">{{ metrics.appointments?.total || 0 }}</div>
+                <div class="text-sm text-gray-600 mt-1">Appointments</div>
+              </div>
+
+              <!-- Employee/Service Stats -->
+              <div class="text-center p-4 bg-pink-50 rounded-lg">
+                <div class="text-3xl font-bold text-pink-600">{{ metrics.employees?.total || 0 }}</div>
+                <div class="text-sm text-gray-600 mt-1">Employees</div>
+              </div>
+              <div class="text-center p-4 bg-amber-50 rounded-lg">
+                <div class="text-3xl font-bold text-amber-600">{{ metrics.services?.total || 0 }}</div>
+                <div class="text-sm text-gray-600 mt-1">Services</div>
               </div>
             </div>
           </template>
@@ -223,14 +288,17 @@ function goBack() {
           </template>
           <template #content>
             <DataTable
+              v-model:expandedRows="expandedRows"
               :value="clients"
               :rows="10"
               :paginator="clients.length > 10"
               responsiveLayout="scroll"
               :loading="loading"
               stripedRows
+              dataKey="id"
               class="text-sm"
             >
+              <Column expander style="width: 3rem" />
               <Column field="name" header="Business Name" sortable>
                 <template #body="{ data }">
                   <div>
@@ -287,6 +355,125 @@ function goBack() {
                 <div class="text-center py-8 text-gray-500">
                   <i class="pi pi-users text-4xl mb-3"></i>
                   <p>No clients found</p>
+                </div>
+              </template>
+
+              <!-- Expandable Row Content -->
+              <template #expansion="{ data }">
+                <div class="p-4 bg-gray-50">
+                  <h4 class="text-lg font-semibold mb-4 text-gray-800">{{ data.name }} - Metrics</h4>
+
+                  <div v-if="data.metrics" class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
+                    <!-- Call Metrics -->
+                    <div class="bg-white p-3 rounded-lg shadow-sm border">
+                      <div class="flex items-center gap-2 mb-1">
+                        <i class="pi pi-phone text-indigo-500"></i>
+                        <span class="text-xs text-gray-500 uppercase">Calls</span>
+                      </div>
+                      <div class="text-2xl font-bold text-gray-800">{{ data.metrics.calls?.total || 0 }}</div>
+                    </div>
+
+                    <div class="bg-white p-3 rounded-lg shadow-sm border">
+                      <div class="flex items-center gap-2 mb-1">
+                        <i class="pi pi-clock text-cyan-500"></i>
+                        <span class="text-xs text-gray-500 uppercase">Call Minutes</span>
+                      </div>
+                      <div class="text-2xl font-bold text-gray-800">{{ data.metrics.calls?.totalMinutes || 0 }}</div>
+                    </div>
+
+                    <!-- Appointment Metrics -->
+                    <div class="bg-white p-3 rounded-lg shadow-sm border">
+                      <div class="flex items-center gap-2 mb-1">
+                        <i class="pi pi-calendar text-teal-500"></i>
+                        <span class="text-xs text-gray-500 uppercase">Appointments</span>
+                      </div>
+                      <div class="text-2xl font-bold text-gray-800">{{ data.metrics.appointments?.total || 0 }}</div>
+                      <div class="text-xs text-gray-500 mt-1">
+                        {{ data.metrics.appointments?.upcoming || 0 }} upcoming
+                      </div>
+                    </div>
+
+                    <div class="bg-white p-3 rounded-lg shadow-sm border">
+                      <div class="flex items-center gap-2 mb-1">
+                        <i class="pi pi-check-circle text-green-500"></i>
+                        <span class="text-xs text-gray-500 uppercase">Completed</span>
+                      </div>
+                      <div class="text-2xl font-bold text-gray-800">{{ data.metrics.appointments?.completed || 0 }}</div>
+                    </div>
+
+                    <div class="bg-white p-3 rounded-lg shadow-sm border">
+                      <div class="flex items-center gap-2 mb-1">
+                        <i class="pi pi-times-circle text-red-500"></i>
+                        <span class="text-xs text-gray-500 uppercase">Cancelled</span>
+                      </div>
+                      <div class="text-2xl font-bold text-gray-800">{{ data.metrics.appointments?.cancelled || 0 }}</div>
+                    </div>
+
+                    <!-- Employee/Service Metrics -->
+                    <div class="bg-white p-3 rounded-lg shadow-sm border">
+                      <div class="flex items-center gap-2 mb-1">
+                        <i class="pi pi-users text-pink-500"></i>
+                        <span class="text-xs text-gray-500 uppercase">Employees</span>
+                      </div>
+                      <div class="text-2xl font-bold text-gray-800">{{ data.metrics.employees || 0 }}</div>
+                    </div>
+
+                    <div class="bg-white p-3 rounded-lg shadow-sm border">
+                      <div class="flex items-center gap-2 mb-1">
+                        <i class="pi pi-list text-amber-500"></i>
+                        <span class="text-xs text-gray-500 uppercase">Services</span>
+                      </div>
+                      <div class="text-2xl font-bold text-gray-800">{{ data.metrics.services || 0 }}</div>
+                    </div>
+
+                    <!-- Phone & Trial Info -->
+                    <div class="bg-white p-3 rounded-lg shadow-sm border">
+                      <div class="flex items-center gap-2 mb-1">
+                        <i class="pi pi-mobile text-blue-500"></i>
+                        <span class="text-xs text-gray-500 uppercase">Phone Number</span>
+                      </div>
+                      <div class="text-sm font-medium text-gray-800">
+                        {{ data.metrics.phoneNumber || 'Not assigned' }}
+                      </div>
+                    </div>
+
+                    <div v-if="data.metrics.trialDaysRemaining !== null" class="bg-white p-3 rounded-lg shadow-sm border">
+                      <div class="flex items-center gap-2 mb-1">
+                        <i class="pi pi-hourglass text-orange-500"></i>
+                        <span class="text-xs text-gray-500 uppercase">Trial Days Left</span>
+                      </div>
+                      <div class="text-2xl font-bold" :class="data.metrics.trialDaysRemaining <= 3 ? 'text-red-600' : 'text-orange-600'">
+                        {{ data.metrics.trialDaysRemaining }}
+                      </div>
+                    </div>
+
+                    <div class="bg-white p-3 rounded-lg shadow-sm border">
+                      <div class="flex items-center gap-2 mb-1">
+                        <i class="pi pi-credit-card text-purple-500"></i>
+                        <span class="text-xs text-gray-500 uppercase">Plan</span>
+                      </div>
+                      <Tag
+                        :value="data.metrics.planType || data.planType || 'free'"
+                        :severity="getPlanSeverity(data.metrics.planType || data.planType || 'free')"
+                        class="uppercase text-xs"
+                      />
+                    </div>
+
+                    <div class="bg-white p-3 rounded-lg shadow-sm border">
+                      <div class="flex items-center gap-2 mb-1">
+                        <i class="pi pi-wallet text-green-500"></i>
+                        <span class="text-xs text-gray-500 uppercase">Stripe</span>
+                      </div>
+                      <div class="text-xs font-medium" :class="data.metrics.stripeCustomerId ? 'text-green-600' : 'text-gray-400'">
+                        {{ data.metrics.stripeCustomerId ? 'Connected' : 'Not connected' }}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div v-else class="text-center py-4 text-gray-500">
+                    <i class="pi pi-info-circle mr-2"></i>
+                    No metrics available for this client
+                  </div>
                 </div>
               </template>
             </DataTable>


### PR DESCRIPTION
## Summary
- Adds platform-wide summary metrics tiles to admin dashboard (total calls, call minutes, appointments, employees, services, active trials, paid clients)
- Adds expandable rows in clients table showing per-client metrics (calls, minutes, appointments, employees, services, phone number, trial days remaining, plan type, Stripe status)
- Creates new GET /api/admin/metrics endpoint for aggregate stats
- Modifies GET /api/admin/clients to include per-client metrics

## Screenshots
Summary tiles show:
- Total Clients / Active Clients / Paid Plans / Active Trials
- Total Calls / Call Minutes
- Appointments / Employees / Services

Expandable rows show per-client:
- Calls, Call Minutes, Appointments (with upcoming count), Completed, Cancelled
- Employees, Services, Phone Number, Trial Days Left, Plan, Stripe Status

## Test Plan
- [ ] Navigate to /criton-admin and login
- [ ] Verify summary tiles display platform-wide metrics
- [ ] Click expand arrow on any client row
- [ ] Verify expanded row shows client-specific metrics
- [ ] Verify refresh button updates both tiles and client metrics

Fixes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)